### PR TITLE
bug: multi-record Key/Key URL favicon display error

### DIFF
--- a/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
+++ b/omero_mapr/templates/webclient/data/includes/right_plugin.general.js.html
@@ -126,12 +126,11 @@ OME.linkify_element = function(elements) {
                     }
                     // If we're on e.g. "Gene Identifier URL" row...
                     if ( _key.match(new RegExp("url", "i"))  ) {
-                        // Find the next previous row where
-                        // row[N-1].key == row[N].key + ' URL'
-                        var $target = $row.prev('tr');
-                        while ($target.length > 0 && $target.children("td:nth-child(1)").text() !== _tkey) {
-                            $target = $target.prev('tr');
-                        }
+                        // Find the first row where
+                        // row[N].key == row.key + ' URL' && row[N].value doesnt have a span.favicon (i.e already processed)
+                        var $target = $row.parent().parent().find("tbody").find("tr").filter(function(){
+                             return $(this).children("td:nth-child(1)").text() === _tkey && $(this).children("td:nth-child(2)").find("span.favicon").length==0
+                        }).first()
                         if ($target.children("td:nth-child(1)").text() === _tkey) {
                             var $targetchvalue = $target.children("td:nth-child(2)");
                             // Take the Favicon html we created with iconify() above


### PR DESCRIPTION
When a Key/Key URL key/value set is being used, and there can be multiple entities in this key set (i.e. the original data was split), favicon icons are being assigned to the last Key record (i.e. the recursively found N-1 record). 

Because the code progresses through the key and key URLs in order, and the order for multi-entries are Key (1), Key (2), Key (3), Key URL (1), Key URL (2), Key URL (3), the following logic was used. Search for all keys with the correct text (logic unchanged), AND where the value TD (td:nth-child(2)) does not have a "span.favicon" element, as adding the span.favicon element indicates that a Key/Key URL has been processed. Finally, return only the first result as the $target.